### PR TITLE
OSOE-1242: Update MailKit to 4.15.1 (security fix)

### DIFF
--- a/Lombiq.EmailClient/Lombiq.EmailClient.csproj
+++ b/Lombiq.EmailClient/Lombiq.EmailClient.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MailKit" Version="4.14.1" />
+    <PackageReference Include="MailKit" Version="4.15.0" />
     <PackageReference Include="OrchardCore.Module.Targets" Version="2.1.0" />
   </ItemGroup>
 

--- a/Lombiq.EmailClient/Lombiq.EmailClient.csproj
+++ b/Lombiq.EmailClient/Lombiq.EmailClient.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MailKit" Version="4.15.0" />
+    <PackageReference Include="MailKit" Version="4.15.1" />
     <PackageReference Include="OrchardCore.Module.Targets" Version="2.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Updates MailKit from 4.14.1 to 4.15.1 (via Renovate 4.15.0 + manual bump to 4.15.1).

This is a security fix for a CRLF injection vulnerability in SMTP commands.

Jira: [OSOE-1242](https://lombiq.atlassian.net/browse/OSOE-1242)

[OSOE-1242]: https://lombiq.atlassian.net/browse/OSOE-1242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ